### PR TITLE
Adaptive grid margin and gutter tokens

### DIFF
--- a/src/modules/grid.scss
+++ b/src/modules/grid.scss
@@ -18,4 +18,30 @@
   --grid-wide-column: 12;
   --grid-wide-margin: 32px;
   --grid-wide-gutter: 32px;
+
+  // These variables automatically adapt to the viewport size,
+  // so that apps don't have to worry about updating the value manually.
+  --grid-margin: var(--grid-mobile-margin);
+  --grid-gutter: var(--grid-mobile-gutter);
+}
+
+@media (min-width: 768px) and (max-width: 1151px) {
+  :root {
+    --grid-margin: var(--grid-tablet-margin);
+    --grid-gutter: var(--grid-tablet-gutter);
+  }
+}
+
+@media (min-width: 1152px) and (max-width: 1365px) {
+  :root {
+    --grid-margin: var(--grid-desktop-margin);
+    --grid-gutter: var(--grid-desktop-gutter);
+  }
+}
+
+@media (min-width: 1366px) {
+  :root {
+    --grid-margin: var(--grid-wide-margin);
+    --grid-gutter: var(--grid-wide-gutter);
+  }
 }

--- a/src/modules/typography.scss
+++ b/src/modules/typography.scss
@@ -10,23 +10,23 @@
   --font-sb: 600;
 
   // font-size type scale
-  --font-size-1: 0.75rem;
-  --font-size-2: 0.875rem;
-  --font-size-3: 1rem;
-  --font-size-4: 1.125rem;
-  --font-size-5: 1.25rem;
-  --font-size-6: 1.5rem;
-  --font-size-7: 1.75rem;
-  --font-size-8: 2rem;
-  --font-size-9: 2.25rem;
-  --font-size-10: 2.625rem;
-  --font-size-11: 3rem;
-  --font-size-12: 3.375rem;
-  --font-size-13: 3.75rem;
-  --font-size-14: 4.25rem;
-  --font-size-15: 4.75rem;
-  --font-size-16: 5.25rem;
-  --font-size-17: 5.75rem;
+  --font-size-1: 0.75rem; // 12px
+  --font-size-2: 0.875rem; // 14px
+  --font-size-3: 1rem; // assuming 16px
+  --font-size-4: 1.125rem; // 18px
+  --font-size-5: 1.25rem; // 20px
+  --font-size-6: 1.5rem; // 24px
+  --font-size-7: 1.75rem; // 28px
+  --font-size-8: 2rem; // 32px
+  --font-size-9: 2.25rem; // 36px
+  --font-size-10: 2.625rem; // 42px
+  --font-size-11: 3rem; // 48px
+  --font-size-12: 3.375rem; // 54px
+  --font-size-13: 3.75rem; // 60px
+  --font-size-14: 4.25rem; // 68px
+  --font-size-15: 4.75rem; // 76px
+  --font-size-16: 5.25rem; // 84px
+  --font-size-17: 5.75rem; // 92px
 
   // backward compatibility
   --dashboard-font: var(--font-family-sans);
@@ -51,7 +51,7 @@
   letter-spacing: 0;
 }
 
-@media (max-width: 1152px - 1) {
+@media (max-width: 1151px) {
   .heading-1,
   .heading-1-sb,
   .heading-1-lt {


### PR DESCRIPTION
This PR adds two new tokens for grid margin and grid gutter, and media queries to make them responsive.
The aim of these tokens is to have a single responsive token for grid margin and gutter, instead of repeating those media queries in every single project.

So for example this
```css
.main-container {
  padding: calc(var(--space-unit) * 2) var(--grid-mobile-margin);
}

@media (min-width: 768px) and (max-width: 1151px) {
  .main-container {
    padding-right: var(--grid-tablet-margin);
    padding-left: var(--grid-tablet-margin);
  }
}

@media (min-width: 1152px) and (max-width: 1365px) {
  .main-container {
    padding-right: var(--grid-desktop-margin);
    padding-left: var(--grid-desktop-margin);
  }
}

@media (min-width: 1366px) {
  .main-container {
    padding-right: var(--grid-desktop-wide-margin);
    padding-left: var(--grid-desktop-wide-margin);
  }
}
```

become this

```css
.main-container {
  padding: calc(var(--space-unit) * 2) var(--grid-margin);
}
```