### PR TITLE
Add CSS class also for default theme

### DIFF
--- a/src/modules/themes/default.scss
+++ b/src/modules/themes/default.scss
@@ -1,4 +1,5 @@
-:root {
+:root,
+.theme-default {
   --color-background: var(--gray50);
 
   --color-primary01: var(--blue500);


### PR DESCRIPTION
This PR adds a CSS class for the default theme, to enable the same usage pattern as other themes.